### PR TITLE
Fix compatibility with Android API < 24

### DIFF
--- a/src/main/java/com/rotilho/jnano/commons/Hashes.java
+++ b/src/main/java/com/rotilho/jnano/commons/Hashes.java
@@ -2,10 +2,6 @@ package com.rotilho.jnano.commons;
 
 import com.rfksystems.blake2b.Blake2b;
 
-import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
-
 final class Hashes {
     private static final int DIGEST_256 = 256 / 8;
 
@@ -17,11 +13,15 @@ final class Hashes {
     }
 
     public static byte[] digest(int digestSize, byte[]... byteArrays) {
-        requireNonNull(byteArrays, "Byte Arrays can't be null");
+    	if (byteArrays == null) {
+    		throw new NullPointerException("Byte Arrays can't be null");
+    	}
 
         Blake2b blake2b = new Blake2b(null, digestSize, null, null);
 
-        Stream.of(byteArrays).forEach(byteArray -> blake2b.update(byteArray, 0, byteArray.length));
+        for (byte[] byteArray: byteArrays) {
+        	blake2b.update(byteArray, 0, byteArray.length);
+        }
 
         byte[] output = new byte[digestSize];
         blake2b.digest(output, 0);

--- a/src/main/java/com/rotilho/jnano/commons/NanoAccountEncodes.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoAccountEncodes.java
@@ -1,8 +1,6 @@
 package com.rotilho.jnano.commons;
 
 import java.util.HashMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.rotilho.jnano.commons.NanoHelper.leftPad;
 import static java.lang.String.valueOf;
@@ -14,19 +12,20 @@ final class NanoAccountEncodes {
     }
 
     static String decode(String encoded) {
-        return encoded.chars()
-                .mapToObj(c -> (char) c)
-                .map(ALPHABET::getBinary)
-                .collect(Collectors.joining());
+    	StringBuilder sb = new StringBuilder();
+    	for (int i = 0; i < encoded.length(); i++) {
+    		sb.append(ALPHABET.getBinary(encoded.charAt(i)));
+    	}
+    	return sb.toString();
     }
-
+  
     static String encode(String decoded) {
         int codeSize = 5;
-        return Stream.iterate(0, i -> i + codeSize)
-                .map(i -> decoded.substring(i, i + codeSize))
-                .map(ALPHABET::getCharacter)
-                .limit(decoded.length() / codeSize)
-                .collect(Collectors.joining());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < decoded.length(); i += codeSize) {
+        	sb.append(ALPHABET.getCharacter(decoded.substring(i, i + codeSize)));
+        }
+        return sb.toString();
     }
 
 

--- a/src/main/java/com/rotilho/jnano/commons/NanoAccounts.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoAccounts.java
@@ -36,7 +36,7 @@ public final class NanoAccounts {
 
     @NonNull
     public static byte[] toPublicKey(@NonNull NanoAccountType type, @NonNull String account) {
-        Preconditions.checkArgument(isValid(type, account), () -> "Invalid account " + account);
+        Preconditions.checkArgument(isValid(type, account),"Invalid account " + account);
         return extractPublicKey(type, account);
     }
 

--- a/src/main/java/com/rotilho/jnano/commons/NanoAmount.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoAmount.java
@@ -13,142 +13,142 @@ import lombok.Value;
 @Getter(AccessLevel.PRIVATE)
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class NanoAmount {
-    @NonNull
-    private final BigDecimal raw;
+	@NonNull
+	private final BigDecimal raw;
 
-    public static NanoAmount of(@NonNull BigDecimal amount, @NonNull NanoUnit unit) {
-        BigDecimal raw = amount.multiply(unit.getMultiplier());
-        if (raw.stripTrailingZeros().scale() > 0) {
-            throw new IllegalArgumentException("Amount(" + amount + ") have raw decimals");
-        }
-        return new NanoAmount(raw);
-    }
+	public static NanoAmount of(@NonNull BigDecimal amount, @NonNull NanoUnit unit) {
+		BigDecimal raw = amount.multiply(unit.getMultiplier());
+		if (raw.stripTrailingZeros().scale() > 0) {
+			throw new IllegalArgumentException("Amount(" + amount + ") have raw decimals");
+		}
+		return new NanoAmount(raw);
+	}
 
-    public static NanoAmount of(@NonNull String amount, @NonNull NanoUnit unit) {
-        return of(new BigDecimal(amount), unit);
-    }
+	public static NanoAmount of(@NonNull String amount, @NonNull NanoUnit unit) {
+		return of(new BigDecimal(amount), unit);
+	}
 
-    public static NanoAmount ofGiga(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.GIGA);
-    }
+	public static NanoAmount ofGiga(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.GIGA);
+	}
 
-    public static NanoAmount ofGiga(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.GIGA);
-    }
+	public static NanoAmount ofGiga(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.GIGA);
+	}
 
-    public static NanoAmount ofNano(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.NANO);
-    }
+	public static NanoAmount ofNano(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.NANO);
+	}
 
-    public static NanoAmount ofNano(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.NANO);
-    }
+	public static NanoAmount ofNano(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.NANO);
+	}
 
-    public static NanoAmount ofKilo(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.KILO);
-    }
+	public static NanoAmount ofKilo(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.KILO);
+	}
 
-    public static NanoAmount ofKilo(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.KILO);
-    }
+	public static NanoAmount ofKilo(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.KILO);
+	}
 
-    public static NanoAmount ofSmallNano(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.SMALL_NANO);
-    }
+	public static NanoAmount ofSmallNano(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.SMALL_NANO);
+	}
 
-    public static NanoAmount ofSmallNano(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.SMALL_NANO);
-    }
+	public static NanoAmount ofSmallNano(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.SMALL_NANO);
+	}
 
-    public static NanoAmount ofMilli(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.MILLI);
-    }
+	public static NanoAmount ofMilli(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.MILLI);
+	}
 
-    public static NanoAmount ofMilli(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.MILLI);
-    }
+	public static NanoAmount ofMilli(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.MILLI);
+	}
 
-    public static NanoAmount ofMicro(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.MICRO);
-    }
+	public static NanoAmount ofMicro(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.MICRO);
+	}
 
-    public static NanoAmount ofMicro(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.MICRO);
-    }
+	public static NanoAmount ofMicro(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.MICRO);
+	}
 
-    public static NanoAmount ofRaw(@NonNull BigDecimal amount) {
-        return NanoAmount.of(amount, NanoUnit.RAW);
-    }
+	public static NanoAmount ofRaw(@NonNull BigDecimal amount) {
+		return NanoAmount.of(amount, NanoUnit.RAW);
+	}
 
-    public static NanoAmount ofRaw(@NonNull String amount) {
-        return NanoAmount.of(amount, NanoUnit.RAW);
-    }
+	public static NanoAmount ofRaw(@NonNull String amount) {
+		return NanoAmount.of(amount, NanoUnit.RAW);
+	}
 
-    public static NanoAmount ofByteArray(@NonNull byte[] amount) {
-        return NanoAmount.of(new BigDecimal(NanoHelper.toBigInteger(amount)), NanoUnit.RAW);
-    }
+	public static NanoAmount ofByteArray(@NonNull byte[] amount) {
+		return NanoAmount.of(new BigDecimal(NanoHelper.toBigInteger(amount)), NanoUnit.RAW);
+	}
 
-    public NanoAmount add(NanoAmount amount) {
-        return NanoAmount.ofRaw(this.raw.add(amount.raw));
-    }
+	public NanoAmount add(NanoAmount amount) {
+		return NanoAmount.ofRaw(this.raw.add(amount.raw));
+	}
 
-    public NanoAmount subtract(@NonNull NanoAmount amount) {
-        return NanoAmount.ofRaw(this.raw.subtract(amount.raw));
-    }
+	public NanoAmount subtract(@NonNull NanoAmount amount) {
+		return NanoAmount.ofRaw(this.raw.subtract(amount.raw));
+	}
 
-    public NanoAmount multiply(@NonNull NanoAmount amount) {
-        return NanoAmount.ofRaw(this.raw.multiply(amount.raw));
-    }
+	public NanoAmount multiply(@NonNull NanoAmount amount) {
+		return NanoAmount.ofRaw(this.raw.multiply(amount.raw));
+	}
 
-    public NanoAmount divide(@NonNull NanoAmount amount, @NonNull RoundingMode roundingMode) {
-        return NanoAmount.ofRaw(this.raw.divide(amount.raw, roundingMode));
-    }
+	public NanoAmount divide(@NonNull NanoAmount amount, @NonNull RoundingMode roundingMode) {
+		return NanoAmount.ofRaw(this.raw.divide(amount.raw, roundingMode));
+	}
 
-    public BigDecimal to(@NonNull NanoUnit unit) {
-        BigDecimal amount = raw.divide(unit.getMultiplier());
-        if (amount.stripTrailingZeros().scale() > 0) {
-            return amount.stripTrailingZeros();
-        }
-        return amount.setScale(0, BigDecimal.ROUND_DOWN);
-    }
+	public BigDecimal to(@NonNull NanoUnit unit) {
+		BigDecimal amount = raw.divide(unit.getMultiplier());
+		if (amount.stripTrailingZeros().scale() > 0) {
+			return amount.stripTrailingZeros();
+		}
+		return amount.setScale(0, BigDecimal.ROUND_DOWN);
+	}
 
-    public BigDecimal toGiga() {
-        return to(NanoUnit.GIGA);
-    }
+	public BigDecimal toGiga() {
+		return to(NanoUnit.GIGA);
+	}
 
-    public BigDecimal toNano() {
-        return to(NanoUnit.NANO);
-    }
+	public BigDecimal toNano() {
+		return to(NanoUnit.NANO);
+	}
 
-    public BigDecimal toKilo() {
-        return to(NanoUnit.KILO);
-    }
+	public BigDecimal toKilo() {
+		return to(NanoUnit.KILO);
+	}
 
-    public BigDecimal toSmallNano() {
-        return to(NanoUnit.SMALL_NANO);
-    }
+	public BigDecimal toSmallNano() {
+		return to(NanoUnit.SMALL_NANO);
+	}
 
-    public BigDecimal toMilli() {
-        return to(NanoUnit.MILLI);
-    }
+	public BigDecimal toMilli() {
+		return to(NanoUnit.MILLI);
+	}
 
-    public BigDecimal toMicro() {
-        return to(NanoUnit.MICRO);
-    }
+	public BigDecimal toMicro() {
+		return to(NanoUnit.MICRO);
+	}
 
-    public BigDecimal toRaw() {
-        return to(NanoUnit.RAW);
-    }
+	public BigDecimal toRaw() {
+		return to(NanoUnit.RAW);
+	}
 
-    public byte[] toByteArray() {
-        return NanoHelper.toByteArray(raw.toBigInteger());
-    }
+	public byte[] toByteArray() {
+		return NanoHelper.toByteArray(raw.toBigInteger());
+	}
 
-    public String toString(@NonNull NanoUnit unit) {
-        return to(unit).toString();
-    }
+	public String toString(@NonNull NanoUnit unit) {
+		return to(unit).toString();
+	}
 
-    public String toString() {
-        return toString(NanoUnit.RAW);
-    }
+	public String toString() {
+		return toString(NanoUnit.RAW);
+	}
 }

--- a/src/main/java/com/rotilho/jnano/commons/NanoBaseAccountType.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoBaseAccountType.java
@@ -1,17 +1,14 @@
 package com.rotilho.jnano.commons;
 
-import java.util.function.Function;
-
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum NanoBaseAccountType implements NanoAccountType {
-    NANO("nano_", "^(xrb_|nano_)[13456789abcdefghijkmnopqrstuwxyz]{60}$", account -> account.startsWith("nano_") ? account.substring(5, 57) : account.substring(4, 56)),
-    BANANO("ban_", "^(ban_)[13456789abcdefghijkmnopqrstuwxyz]{60}$", account -> account.substring(4, 56));
+    NANO("nano_", "^(xrb_|nano_)[13456789abcdefghijkmnopqrstuwxyz]{60}$"),
+    BANANO("ban_", "^(ban_)[13456789abcdefghijkmnopqrstuwxyz]{60}$");
 
     private final String prefix;
     private final String regex;
-    private final Function<String, String> accountExtractor;
 
     @Override
     public String prefix() {
@@ -25,6 +22,9 @@ public enum NanoBaseAccountType implements NanoAccountType {
 
     @Override
     public String extractEncodedPublicKey(String account) {
-        return accountExtractor.apply(account);
+        if (prefix.contains("nano")) {
+            return account.startsWith("nano_") ? account.substring(5, 57) : account.substring(4, 56);
+        }
+        return account.substring(4, 56);
     }
 }

--- a/src/main/java/com/rotilho/jnano/commons/NanoKeys.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoKeys.java
@@ -9,8 +9,8 @@ public final class NanoKeys {
     }
 
     public static byte[] createPrivateKey(@NonNull byte[] seed, int index) {
-        Preconditions.checkArgument(NanoSeeds.isValid(seed), () -> "Invalid seed " + seed);
-        Preconditions.checkArgument(index >= 0, () -> "Invalid index " + index);
+        Preconditions.checkArgument(NanoSeeds.isValid(seed), "Invalid seed " + seed);
+        Preconditions.checkArgument(index >= 0, "Invalid index " + index);
         return Hashes.digest256(seed, ByteBuffer.allocate(4).putInt(index).array());
     }
 

--- a/src/main/java/com/rotilho/jnano/commons/NanoMnemonics.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoMnemonics.java
@@ -49,7 +49,7 @@ public final class NanoMnemonics {
 
     @NonNull
     public static byte[] bip39ToSeed(@NonNull List<String> mnemonic, @NonNull NanoMnemonicLanguage language) {
-        Preconditions.checkArgument(isValid(mnemonic, language), () -> "Invalid mnemonic");
+        Preconditions.checkArgument(isValid(mnemonic, language), "Invalid mnemonic");
         byte[] seedWithChecksum = extractSeedWithChecksum(mnemonic, language);
         try {
             return extractSeed(seedWithChecksum);

--- a/src/main/java/com/rotilho/jnano/commons/NanoMnemonics.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoMnemonics.java
@@ -148,13 +148,12 @@ public final class NanoMnemonics {
 
         private final List<String> dictionary;
         private final Map<String, Integer> dictionaryMap;
-        private final Map<String, Integer> tempDictionaryMap;
-        
+
         NanoMnemonicLanguage(String fileName) {
             try {
                 URL fileLocation = getClassLoader().getResource(fileName);
                 this.dictionary = unmodifiableList(Files.readAllLines(Paths.get(fileLocation.toURI())));
-                tempDictionaryMap = new HashMap<>();
+                Map<String, Integer> tempDictionaryMap = new HashMap<>();
                 for (String word: dictionary) {
                 	tempDictionaryMap.put(word, dictionary.indexOf(word));
                 }

--- a/src/main/java/com/rotilho/jnano/commons/NanoMnemonics.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoMnemonics.java
@@ -7,7 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,9 +18,6 @@ import lombok.NonNull;
 import static java.util.Arrays.copyOf;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.IntStream.range;
 
 
 public final class NanoMnemonics {
@@ -37,10 +36,11 @@ public final class NanoMnemonics {
         int mnemonicSentenceLength = (seedLength + checksumLength) / 11;
 
         try {
-            return range(0, mnemonicSentenceLength)
-                    .map(i -> next11Bits(seedWithChecksum, i * 11))
-                    .mapToObj(language::getWord)
-                    .collect(toList());
+        	List<String> ret = new ArrayList<>();
+        	for (int i = 0; i < mnemonicSentenceLength; i++) {
+        		ret.add(language.getWord(next11Bits(seedWithChecksum, i * 11)));
+        	}
+        	return ret;
         } finally {
             NanoHelper.wipe(seedWithChecksum);
         }
@@ -81,11 +81,15 @@ public final class NanoMnemonics {
         int seedWithChecksumLength = mnemonicSentenceLength * 11;
         byte[] seedWithChecksum = new byte[(seedWithChecksumLength + 7) / 8];
 
-        List<Integer> mnemonicIndexes = mnemonic.stream()
-                .map(language::getIndex)
-                .collect(toList());
+        
+        List<Integer> mnemonicIndexes = new ArrayList<>();
+        for (String word: mnemonic) {
+        	mnemonicIndexes.add(language.getIndex(word));
+        }
 
-        range(0, mnemonicSentenceLength).forEach(i -> writeNext11(seedWithChecksum, mnemonicIndexes.get(i), i * 11));
+        for (int i = 0; i < mnemonicSentenceLength; i++) {
+        	writeNext11(seedWithChecksum, mnemonicIndexes.get(i), i * 11);
+        }
 
         return seedWithChecksum;
     }
@@ -144,12 +148,17 @@ public final class NanoMnemonics {
 
         private final List<String> dictionary;
         private final Map<String, Integer> dictionaryMap;
-
+        private final Map<String, Integer> tempDictionaryMap;
+        
         NanoMnemonicLanguage(String fileName) {
             try {
                 URL fileLocation = getClassLoader().getResource(fileName);
                 this.dictionary = unmodifiableList(Files.readAllLines(Paths.get(fileLocation.toURI())));
-                this.dictionaryMap = unmodifiableMap(range(0, dictionary.size()).boxed().collect(toMap(dictionary::get, i -> i)));
+                tempDictionaryMap = new HashMap<>();
+                for (String word: dictionary) {
+                	tempDictionaryMap.put(word, dictionary.indexOf(word));
+                }
+                this.dictionaryMap = unmodifiableMap(tempDictionaryMap);
             } catch (Exception e) {
                 throw new IllegalStateException("Could'nt read file " + fileName, e);
             }

--- a/src/main/java/com/rotilho/jnano/commons/NanoSignatures.java
+++ b/src/main/java/com/rotilho/jnano/commons/NanoSignatures.java
@@ -36,6 +36,6 @@ public final class NanoSignatures {
     }
 
     private static void checkHash(String hash) {
-        Preconditions.checkArgument(NanoBlocks.isValid(hash), () -> "Invalid hash " + hash);
+        Preconditions.checkArgument(NanoBlocks.isValid(hash), "Invalid hash " + hash);
     }
 }

--- a/src/main/java/com/rotilho/jnano/commons/Preconditions.java
+++ b/src/main/java/com/rotilho/jnano/commons/Preconditions.java
@@ -1,31 +1,29 @@
 package com.rotilho.jnano.commons;
 
-import java.util.function.Supplier;
-
 final class Preconditions {
     private Preconditions() {
     }
 
-    static void checkArgument(boolean expression, Supplier<String> supplier) {
+    static void checkArgument(boolean expression, String msg) {
         if (!expression) {
-            throw new IllegalArgumentException(supplier.get());
+            throw new IllegalArgumentException(msg);
         }
     }
 
     static void checkHash(byte[] hash) {
-        checkArgument(hash.length == 32, () -> "Invalid hash length");
+        checkArgument(hash.length == 32, "Invalid hash length");
     }
 
     static void checkSignature(byte[] signature) {
-        checkArgument(signature.length == 64, () -> "Invalid signature length");
+        checkArgument(signature.length == 64, "Invalid signature length");
     }
 
     static void checkKey(byte[] key) {
-        checkArgument(key.length == 32, () -> "Invalid key length");
+        checkArgument(key.length == 32, "Invalid key length");
     }
 
 
     static void checkSeed(byte[] seed) {
-        checkArgument(seed.length == 32, () -> "Invalid seed length");
+        checkArgument(seed.length == 32, "Invalid seed length");
     }
 }


### PR DESCRIPTION
The rationale of these changes is mainly android-focused,  some java 8+ features (Streams, some lambdas, etc.) only work in Android API v24+

We still have ~30% of Android devices running on pre-v24 android versions, so in that regard it makes sense as Android developers probably want to include that audience when developing their apps.

So this PR just rewrites some parts of various classes to not use java 8+ features (no Streams, lambdas, functional interfaces, etc.)

Does not address:
1) NanoWorks
2) Seed generation `getInstanceStrong()` is not supported until API level 26 on android

fixes #3 